### PR TITLE
drivers 0.2.11

### DIFF
--- a/HSTB/drivers/__version__.py
+++ b/HSTB/drivers/__version__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 2, 10)
+VERSION = (0, 2, 11)
 __version__ = '.'.join(map(str, VERSION))

--- a/HSTB/drivers/kmall.py
+++ b/HSTB/drivers/kmall.py
@@ -3900,6 +3900,20 @@ class kmall():
         recs_to_read = self._skm_remove_empty_navigation(recs_to_read)
         recs_to_read = self._merge_detectioninfo_detectionmethod(recs_to_read)
 
+        # need to sort/drop uniques, keep finding duplicate times
+        for dset_name in ['attitude', 'navigation', 'ping']:
+            dset = recs_to_read[dset_name]
+            _, index = np.unique(dset['time'], return_index=True)
+            if dset['time'].size != index.size:
+                # print('kmall: Found duplicate times in {}, removing...'.format(dset_name))
+                for var in dset:
+                    dset[var] = dset[var][index]
+            if not np.all(dset['time'][:-1] <= dset['time'][1:]):
+                # print('kmall: {} is not sorted, sorting...'.format(dset_name))
+                index = np.argsort(dset['time'])
+                for var in dset:
+                    dset[var] = dset[var][index]
+
         # some dtype setting to appease the Kluster check
         recs_to_read['runtime_params']['runtime_settings'] = np.array(recs_to_read['runtime_params']['runtime_settings'], dtype=np.object)
         # empty processing status that we append for Kluster to use later

--- a/HSTB/drivers/kmall.py
+++ b/HSTB/drivers/kmall.py
@@ -3849,8 +3849,8 @@ class kmall():
             inst_params = recs_to_read['installation_params']['installation_settings'][0]
             if inst_params is not None and serial_translator is not None:
                 serialnums = list(serial_translator.values())
-                recs_to_read['installation_params']['serial_one'] = np.array(serialnums[0], dtype='uint16')
-                recs_to_read['installation_params']['serial_two'] = np.array(serialnums[1], dtype='uint16')
+                recs_to_read['installation_params']['serial_one'] = np.array(serialnums[0], dtype='uint64')
+                recs_to_read['installation_params']['serial_two'] = np.array(serialnums[1], dtype='uint64')
                 recs_to_read['ping']['serial_num'][recs_to_read['ping']['serial_num'] == 0] = serialnums[0]
                 recs_to_read['ping']['serial_num'][recs_to_read['ping']['serial_num'] == 1] = serialnums[1]
 
@@ -3879,7 +3879,7 @@ class kmall():
                     elif dgram in ['soundspeed', 'tiltangle', 'delay', 'beampointingangle', 'traveltime', 'qualityfactor', 'reflectivity']:
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='float32')
                     elif dgram == 'serial_num':
-                        recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint16')
+                        recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint64')
                     elif dgram == 'txsector_beam':
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint8')
                     elif dgram == 'counter':
@@ -4311,11 +4311,10 @@ class kmall():
         if rec is None:
             raise ValueError('kmall: Unable to find installation parameters in file {}'.format(self.filename))
 
-        try:
-            serialnumber = int(rec['install_txt']['pu_serial_number'])
-            serialnumbertwo = 0  # currently there is no support for dual head in kmall files
-        except:
-            raise ValueError('Error: Unable to find pu_serial_number in kmall IIP install_txt')
+        serial_trans = self.fast_read_serial_number_translator()
+        serialnumber = serial_trans[0]
+        serialnumbertwo = serial_trans[1]
+
         try:
             sonarmodel = rec['install_txt']['sonar_model_number'].lower()
         except:

--- a/HSTB/drivers/par3.py
+++ b/HSTB/drivers/par3.py
@@ -740,6 +740,8 @@ class AllRead:
                     elif dgram == 'detectioninfo':
                         # same for detection info, but it also needs to be converted to something other than int8
                         recs_to_read[rec][dgram] = self._translate_to_array(recs_to_read[rec][dgram], override_type=np.int32, uneven=uneven, maxlen=maxlen, fullwith=2)
+                    elif dgram == 'serial_num':
+                        recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint64')
                     elif dgram == 'qualityfactor':
                         if uneven:
                             newrec = np.zeros((len(recs_to_read[rec][dgram]), maxlen), dtype=np.float32)

--- a/HSTB/drivers/par3.py
+++ b/HSTB/drivers/par3.py
@@ -836,26 +836,27 @@ class AllRead:
             recs_to_read['ping']['detectioninfo'][msk] = 2
             recs_to_read['ping']['traveltime'][msk] = np.float32(np.nan)
 
-        # need to sort/drop uniques, keep finding duplicate times in attitude/navigation datasets
-        for dset_name in ['attitude', 'navigation']:
+        # need to sort/drop uniques, keep finding duplicate times
+        for dset_name in ['attitude', 'navigation', 'ping']:
             # first handle these cases where variables are of a different size vs time, I believe this is some issue with older datasets
             #  and the data65 record, need to determine the actual cause as the 'fix' used here is not great
-            for dgram in recs_to_read[dset_name]:
-                if dgram != 'time':
-                    try:
-                        assert recs_to_read[dset_name][dgram].shape[0] == recs_to_read[dset_name]['time'].shape[0]
-                    except AssertionError:
-                        dgramsize = recs_to_read[dset_name][dgram].shape[0]
-                        timesize = recs_to_read[dset_name]["time"].shape[0]
-                        msg = f'variable {dgram} has a length of {dgramsize}, where time has a length of {timesize}'
-                        if recs_to_read[dset_name][dgram].ndim == 2:  # shouldn't be seen with attitude/navigation datasets anyway
-                            raise NotImplementedError(msg + ', handling this for 2 dimensional cases is not implemented')
-                        elif timesize < dgramsize:  # trim to time size
-                            recs_to_read[dset_name][dgram] = recs_to_read[dset_name][dgram][:timesize]
-                            print('Warning: ' + msg + f', trimming {dgram} to length {timesize}')
-                        else:
-                            recs_to_read[dset_name][dgram] = np.concatenate([recs_to_read[dset_name][dgram], [recs_to_read[dset_name][dgram][-1]] * (timesize - dgramsize)])
-                            print('Warning: ' + msg + f', filling {dgram} by repeating last element {timesize - dgramsize} times')
+            if dset_name in ['attitude', 'navigation']:
+                for dgram in recs_to_read[dset_name]:
+                    if dgram != 'time':
+                        try:
+                            assert recs_to_read[dset_name][dgram].shape[0] == recs_to_read[dset_name]['time'].shape[0]
+                        except AssertionError:
+                            dgramsize = recs_to_read[dset_name][dgram].shape[0]
+                            timesize = recs_to_read[dset_name]["time"].shape[0]
+                            msg = f'variable {dgram} has a length of {dgramsize}, where time has a length of {timesize}'
+                            if recs_to_read[dset_name][dgram].ndim == 2:  # shouldn't be seen with attitude/navigation datasets anyway
+                                raise NotImplementedError(msg + ', handling this for 2 dimensional cases is not implemented')
+                            elif timesize < dgramsize:  # trim to time size
+                                recs_to_read[dset_name][dgram] = recs_to_read[dset_name][dgram][:timesize]
+                                print('Warning: ' + msg + f', trimming {dgram} to length {timesize}')
+                            else:
+                                recs_to_read[dset_name][dgram] = np.concatenate([recs_to_read[dset_name][dgram], [recs_to_read[dset_name][dgram][-1]] * (timesize - dgramsize)])
+                                print('Warning: ' + msg + f', filling {dgram} by repeating last element {timesize - dgramsize} times')
 
             dset = recs_to_read[dset_name]
             _, index = np.unique(dset['time'], return_index=True)

--- a/HSTB/drivers/prr3.py
+++ b/HSTB/drivers/prr3.py
@@ -750,8 +750,8 @@ class X7kRead:
             isets['transducer_2_vertical_location'] = runtime['transducer_2_vertical_refpt_offset']
 
         finalrec = {'installation_params': {'time': np.array([starttime], dtype=float),
-                                            'serial_one': np.array([serial_num_one], dtype=np.dtype('uint16')),
-                                            'serial_two': np.array([serial_num_two], dtype=np.dtype('uint16')),
+                                            'serial_one': np.array([serial_num_one], dtype=np.dtype('uint64')),
+                                            'serial_two': np.array([serial_num_two], dtype=np.dtype('uint64')),
                                             'installation_settings': np.array([isets], dtype=np.object)}}
         return finalrec
 
@@ -845,7 +845,7 @@ class X7kRead:
         recs_to_read['ping']['detectioninfo'] = translate_detectioninfo(recs_to_read['ping']['detectioninfo'])
 
         # empty records we expect with sector wise systems that we need to cover for Kluster
-        recs_to_read['ping']['serial_num'] = np.full(recs_to_read['ping']['counter'].shape, serialnumber, dtype='uint16')
+        recs_to_read['ping']['serial_num'] = np.full(recs_to_read['ping']['counter'].shape, serialnumber, dtype='uint64')
         recs_to_read['ping']['delay'] = np.full_like(recs_to_read['ping']['tiltangle'], 0.0)
 
         # drop the empty altitude record if it is empty


### PR DESCRIPTION
update multibeam drivers to use uint64 serial number
kmall driver will use serial translator when returning fast read serial number
add some logic to multibeam drivers sequential_read method, to prevent duplicate times