### PR TITLE
drivers 0.3.0

### DIFF
--- a/HSTB/drivers/__version__.py
+++ b/HSTB/drivers/__version__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 2, 12)
+VERSION = (0, 3, 0)
 __version__ = '.'.join(map(str, VERSION))

--- a/HSTB/drivers/kmall.py
+++ b/HSTB/drivers/kmall.py
@@ -3840,6 +3840,10 @@ class kmall():
         return recs_to_read
 
     def _finalize_ping_record(self, arr, dtyp, maxlen):
+        """
+        Take in the list of numpy arrays, and merge them into a single array by casting as ndarray.  If you get a sonar
+        with a varying number of beams, you have to go the iterate-over-all-pings route instead, which is slower.
+        """
         try:
             if dtyp is not None:
                 newrec = np.array(arr, dtype=dtyp)

--- a/HSTB/drivers/kmall.py
+++ b/HSTB/drivers/kmall.py
@@ -3666,7 +3666,7 @@ class kmall():
                                    'txSectorInfo.totalSignalLength_sec',
                                    'sounding.beamAngleReRx_deg', 'sounding.reflectivity2_dB', 'sounding.txSectorNumb', 'sounding.detectionType',
                                    'sounding.detectionMethod', 'sounding.qualityFactor', 'sounding.twoWayTravelTime_sec',
-                                   'sounding.meanAbsCoeff_dbPerkm', 'sounding.TVG_dB',
+                                   'sounding.receiverSensitivityApplied_dB', 'sounding.sourceLevelApplied_dB', 'sounding.TVG_dB',
                                    'pingInfo.modeAndStabilisation', 'pingInfo.pulseForm', 'pingInfo.depthMode',
                                    'pingInfo.latitude_deg', 'pingInfo.longitude_deg', 'pingInfo.ellipsoidHeightReRefPoint_m'],
                            'IOP': ['header.dgtime', 'runtime_txt'],
@@ -3692,7 +3692,8 @@ class kmall():
                                               'sounding.detectionMethod': [['ping', 'detectioninfo_two']],
                                               'sounding.qualityFactor': [['ping', 'qualityfactor']],
                                               'sounding.twoWayTravelTime_sec': [['ping', 'traveltime']],
-                                              'sounding.meanAbsCoeff_dbPerkm': [['ping', 'absorption']],
+                                              'sounding.receiverSensitivityApplied_dB': [['ping', 'receiversensitivity']],
+                                              'sounding.sourceLevelApplied_dB': [['ping', 'sourceLevel']],
                                               'sounding.TVG_dB': [['ping', 'tvg']],
                                               'pingInfo.modeAndStabilisation': [['ping', 'yawpitchstab']],
                                               'pingInfo.pulseForm': [['ping', 'mode']],
@@ -3715,7 +3716,7 @@ class kmall():
             'ping': {'time': None, 'counter': None, 'soundspeed': None, 'serial_num': None, 'tiltangle': None,
                      'delay': None, 'frequency': None, 'beampointingangle': None, 'reflectivity': None, 'txsector_beam': None,
                      'detectioninfo': None, 'detectioninfo_two': None, 'qualityfactor': None, 'traveltime': None,
-                     'absorption': None, 'pulselength': None, 'tvg': None,
+                     'receiversensitivity': None, 'pulselength': None, 'tvg': None, 'sourceLevel': None,
                      'mode': None, 'modetwo': None, 'yawpitchstab': None},
             'runtime_params': {'time': None, 'runtime_settings': None},
             'profile': {'time': None, 'depth': None, 'soundspeed': None},
@@ -3886,7 +3887,7 @@ class kmall():
                     elif dgram == 'modetwo':
                         recs_to_read[rec][dgram] = self.translate_mode_two_tostring(np.array(recs_to_read[rec][dgram]))
                     elif dgram in ['soundspeed', 'tiltangle', 'delay', 'beampointingangle', 'traveltime', 'qualityfactor',
-                                   'reflectivity', 'pulselength', 'tvg', 'absorption']:
+                                   'reflectivity', 'pulselength', 'tvg', 'sourceLevel', 'receiversensitivity']:
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='float32')
                     elif dgram == 'serial_num':
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint64')
@@ -3909,6 +3910,7 @@ class kmall():
         # recs_to_read = self._interpolate_skm_time_spikes(recs_to_read)
         recs_to_read = self._skm_remove_empty_navigation(recs_to_read)
         recs_to_read = self._merge_detectioninfo_detectionmethod(recs_to_read)
+        recs_to_read['ping']['fixedgain'] = recs_to_read['ping'].pop('sourceLevel') + recs_to_read['ping'].pop('receiversensitivity')
 
         # need to sort/drop uniques, keep finding duplicate times
         for dset_name in ['attitude', 'navigation', 'ping']:

--- a/HSTB/drivers/kmall.py
+++ b/HSTB/drivers/kmall.py
@@ -3665,7 +3665,7 @@ class kmall():
                                    'txSectorInfo.tiltAngleReTx_deg', 'txSectorInfo.sectorTransmitDelay_sec', 'txSectorInfo.centreFreq_Hz',
                                    'txSectorInfo.totalSignalLength_sec',
                                    'sounding.beamAngleReRx_deg', 'sounding.reflectivity2_dB', 'sounding.txSectorNumb', 'sounding.detectionType',
-                                   'sounding.detectionMethod', 'sounding.qualityFactor', 'sounding.twoWayTravelTime_sec',
+                                   'sounding.detectionMethod', 'sounding.qualityFactor', 'sounding.twoWayTravelTime_sec', 'sounding.meanAbsCoeff_dbPerkm',
                                    'sounding.receiverSensitivityApplied_dB', 'sounding.sourceLevelApplied_dB', 'sounding.TVG_dB',
                                    'pingInfo.modeAndStabilisation', 'pingInfo.pulseForm', 'pingInfo.depthMode',
                                    'pingInfo.latitude_deg', 'pingInfo.longitude_deg', 'pingInfo.ellipsoidHeightReRefPoint_m'],
@@ -3693,6 +3693,7 @@ class kmall():
                                               'sounding.qualityFactor': [['ping', 'qualityfactor']],
                                               'sounding.twoWayTravelTime_sec': [['ping', 'traveltime']],
                                               'sounding.receiverSensitivityApplied_dB': [['ping', 'receiversensitivity']],
+                                              'sounding.meanAbsCoeff_dbPerkm': [['ping', 'absorption']],
                                               'sounding.sourceLevelApplied_dB': [['ping', 'sourceLevel']],
                                               'sounding.TVG_dB': [['ping', 'tvg']],
                                               'pingInfo.modeAndStabilisation': [['ping', 'yawpitchstab']],
@@ -3716,7 +3717,7 @@ class kmall():
             'ping': {'time': None, 'counter': None, 'soundspeed': None, 'serial_num': None, 'tiltangle': None,
                      'delay': None, 'frequency': None, 'beampointingangle': None, 'reflectivity': None, 'txsector_beam': None,
                      'detectioninfo': None, 'detectioninfo_two': None, 'qualityfactor': None, 'traveltime': None,
-                     'receiversensitivity': None, 'pulselength': None, 'tvg': None, 'sourceLevel': None,
+                     'receiversensitivity': None, 'pulselength': None, 'tvg': None, 'sourceLevel': None, 'absorption': None,
                      'mode': None, 'modetwo': None, 'yawpitchstab': None},
             'runtime_params': {'time': None, 'runtime_settings': None},
             'profile': {'time': None, 'depth': None, 'soundspeed': None},
@@ -3887,7 +3888,7 @@ class kmall():
                     elif dgram == 'modetwo':
                         recs_to_read[rec][dgram] = self.translate_mode_two_tostring(np.array(recs_to_read[rec][dgram]))
                     elif dgram in ['soundspeed', 'tiltangle', 'delay', 'beampointingangle', 'traveltime', 'qualityfactor',
-                                   'reflectivity', 'pulselength', 'tvg', 'sourceLevel', 'receiversensitivity']:
+                                   'reflectivity', 'pulselength', 'tvg', 'sourceLevel', 'receiversensitivity', 'absorption']:
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='float32')
                     elif dgram == 'serial_num':
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint64')

--- a/HSTB/drivers/kmall.py
+++ b/HSTB/drivers/kmall.py
@@ -3632,11 +3632,13 @@ class kmall():
             populated_delay = np.empty(txsector_index.shape, dtype=np.float32)
             populated_freq = np.empty(txsector_index.shape, dtype=np.int32)
             populated_tiltangle = np.empty(txsector_index.shape, dtype=np.float32)
+            populated_pulselength = np.empty(txsector_index.shape, dtype=np.float32)
             try:
                 for id in np.unique(txsector_index):
                     populated_delay[txsector_index == id] = rec['txSectorInfo']['sectorTransmitDelay_sec'][id]
                     populated_freq[txsector_index == id] = rec['txSectorInfo']['centreFreq_Hz'][id]
                     populated_tiltangle[txsector_index == id] = rec['txSectorInfo']['tiltAngleReTx_deg'][id]
+                    populated_pulselength[txsector_index == id] = rec['txSectorInfo']['totalSignalLength_sec'][id]
             except:
                 # this is a duplicate, happens when running sequential read with start_ptr/end_ptr, eof doesnt kick in
                 # shows here because 'Delay', etc.  are already removed from rec.tx
@@ -3645,6 +3647,7 @@ class kmall():
             rec['txSectorInfo']['tiltAngleReTx_deg'] = populated_tiltangle.tolist()
             rec['txSectorInfo']['centreFreq_Hz'] = populated_freq.tolist()
             rec['txSectorInfo']['sectorTransmitDelay_sec'] = populated_delay.tolist()
+            rec['txSectorInfo']['totalSignalLength_sec'] = populated_pulselength.tolist()
 
             return rec
 
@@ -3660,8 +3663,10 @@ class kmall():
                            'MRZ': ['header.dgtime', 'cmnPart.pingCnt',
                                    'pingInfo.soundSpeedAtTxDepth_mPerSec', 'txSectorInfo.txArrNumber',
                                    'txSectorInfo.tiltAngleReTx_deg', 'txSectorInfo.sectorTransmitDelay_sec', 'txSectorInfo.centreFreq_Hz',
+                                   'txSectorInfo.totalSignalLength_sec',
                                    'sounding.beamAngleReRx_deg', 'sounding.reflectivity2_dB', 'sounding.txSectorNumb', 'sounding.detectionType',
                                    'sounding.detectionMethod', 'sounding.qualityFactor', 'sounding.twoWayTravelTime_sec',
+                                   'sounding.meanAbsCoeff_dbPerkm', 'sounding.TVG_dB',
                                    'pingInfo.modeAndStabilisation', 'pingInfo.pulseForm', 'pingInfo.depthMode',
                                    'pingInfo.latitude_deg', 'pingInfo.longitude_deg', 'pingInfo.ellipsoidHeightReRefPoint_m'],
                            'IOP': ['header.dgtime', 'runtime_txt'],
@@ -3679,6 +3684,7 @@ class kmall():
                                               'txSectorInfo.tiltAngleReTx_deg': [['ping', 'tiltangle']],
                                               'txSectorInfo.sectorTransmitDelay_sec': [['ping', 'delay']],
                                               'txSectorInfo.centreFreq_Hz': [['ping', 'frequency']],
+                                              'txSectorInfo.totalSignalLength_sec': [['ping', 'pulselength']],
                                               'sounding.beamAngleReRx_deg': [['ping', 'beampointingangle']],
                                               'sounding.reflectivity2_dB': [['ping', 'reflectivity']],
                                               'sounding.txSectorNumb': [['ping', 'txsector_beam']],
@@ -3686,6 +3692,8 @@ class kmall():
                                               'sounding.detectionMethod': [['ping', 'detectioninfo_two']],
                                               'sounding.qualityFactor': [['ping', 'qualityfactor']],
                                               'sounding.twoWayTravelTime_sec': [['ping', 'traveltime']],
+                                              'sounding.meanAbsCoeff_dbPerkm': [['ping', 'absorption']],
+                                              'sounding.TVG_dB': [['ping', 'tvg']],
                                               'pingInfo.modeAndStabilisation': [['ping', 'yawpitchstab']],
                                               'pingInfo.pulseForm': [['ping', 'mode']],
                                               'pingInfo.depthMode': [['ping', 'modetwo']],
@@ -3707,6 +3715,7 @@ class kmall():
             'ping': {'time': None, 'counter': None, 'soundspeed': None, 'serial_num': None, 'tiltangle': None,
                      'delay': None, 'frequency': None, 'beampointingangle': None, 'reflectivity': None, 'txsector_beam': None,
                      'detectioninfo': None, 'detectioninfo_two': None, 'qualityfactor': None, 'traveltime': None,
+                     'absorption': None, 'pulselength': None, 'tvg': None,
                      'mode': None, 'modetwo': None, 'yawpitchstab': None},
             'runtime_params': {'time': None, 'runtime_settings': None},
             'profile': {'time': None, 'depth': None, 'soundspeed': None},
@@ -3876,7 +3885,8 @@ class kmall():
                         recs_to_read[rec][dgram] = self.translate_mode_tostring(np.array(recs_to_read[rec][dgram]))
                     elif dgram == 'modetwo':
                         recs_to_read[rec][dgram] = self.translate_mode_two_tostring(np.array(recs_to_read[rec][dgram]))
-                    elif dgram in ['soundspeed', 'tiltangle', 'delay', 'beampointingangle', 'traveltime', 'qualityfactor', 'reflectivity']:
+                    elif dgram in ['soundspeed', 'tiltangle', 'delay', 'beampointingangle', 'traveltime', 'qualityfactor',
+                                   'reflectivity', 'pulselength', 'tvg', 'absorption']:
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='float32')
                     elif dgram == 'serial_num':
                         recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram], dtype='uint64')

--- a/HSTB/drivers/par3.py
+++ b/HSTB/drivers/par3.py
@@ -74,11 +74,12 @@ recs_categories_80 = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data.Heave
                       '73': ['time', 'header.Serial#', 'header.Serial#2', 'settings'],
                       '78': ['time', 'header.Counter', 'header.SoundSpeed', 'header.Serial#',
                              'rx.TiltAngle', 'rx.Delay', 'rx.Frequency', 'rx.BeamPointingAngle',
-                             'rx.TransmitSectorID', 'rx.DetectionInfo', 'rx.QualityFactor', 'rx.TravelTime'],
+                             'rx.TransmitSectorID', 'rx.DetectionInfo', 'rx.QualityFactor', 'rx.TravelTime',
+                             'rx.SignalLength'],
                       '82': ['time', 'header.Mode', 'header.ReceiverFixedGain', 'header.YawAndPitchStabilization', 'settings'],
                       '85': ['time', 'data.Depth', 'data.SoundSpeed'],
                       '80': ['time', 'Latitude', 'Longitude', 'gg_data.Altitude'],
-                      '89': ['time', 'Reflectivity']}
+                      '89': ['time', 'Reflectivity', 'MinTravelTime', 'NormalBackscatter', 'ObliqueBackscatter', 'TVGCrossover']}
 
 recs_categories_translator_80 = {'65': {'Time': [['attitude', 'time']], 'Roll': [['attitude', 'roll']],
                                         'Pitch': [['attitude', 'pitch']], 'Heave': [['attitude', 'heave']],
@@ -92,7 +93,8 @@ recs_categories_translator_80 = {'65': {'Time': [['attitude', 'time']], 'Roll': 
                                         'Serial#': [['ping', 'serial_num']], 'TiltAngle': [['ping', 'tiltangle']], 'Delay': [['ping', 'delay']],
                                         'Frequency': [['ping', 'frequency']], 'BeamPointingAngle': [['ping', 'beampointingangle']],
                                         'TransmitSectorID': [['ping', 'txsector_beam']], 'DetectionInfo': [['ping', 'detectioninfo']],
-                                        'QualityFactor': [['ping', 'qualityfactor']], 'TravelTime': [['ping', 'traveltime']]},
+                                        'QualityFactor': [['ping', 'qualityfactor']], 'TravelTime': [['ping', 'traveltime']],
+                                        'SignalLength': [['ping', 'pulselength']]},
                                  '82': {'time': [['runtime_params', 'time']], 'Mode': [['runtime_params', 'mode']],
                                         'ReceiverFixedGain': [['runtime_params', 'modetwo']],
                                         'YawAndPitchStabilization': [['runtime_params', 'yawpitchstab']],
@@ -102,16 +104,18 @@ recs_categories_translator_80 = {'65': {'Time': [['attitude', 'time']], 'Roll': 
                                  '80': {'time': [['navigation', 'time']], 'Latitude': [['navigation', 'latitude']],
                                         'Longitude': [['navigation', 'longitude']],
                                         'Altitude': [['navigation', 'altitude']]},
-                                 '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']]}}
+                                 '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']],
+                                        'MinTravelTime': [['ping', 'mintraveltime']], 'NormalBackscatter': [['ping', 'normalbackscatter']],
+                                        'ObliqueBackscatter': [['ping', 'obliquebackscatter']], 'TVGCrossover': [['ping', 'tvgcrossover']]}}
 
 recs_categories_110 = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data.Heave', 'data.Heading'],
                        '73': ['time', 'header.Serial#', 'header.Serial#2', 'settings'],
                        '78': ['time', 'header.Counter', 'header.SoundSpeed', 'header.Serial#',
                               'rx.TiltAngle', 'rx.Delay', 'rx.Frequency', 'rx.BeamPointingAngle',
-                              'rx.TransmitSectorID', 'rx.DetectionInfo', 'rx.QualityFactor', 'rx.TravelTime'],
+                              'rx.TransmitSectorID', 'rx.DetectionInfo', 'rx.QualityFactor', 'rx.TravelTime', 'rx.SignalLength'],
                        '82': ['time', 'header.Mode', 'header.ReceiverFixedGain', 'header.YawAndPitchStabilization', 'settings'],
                        '85': ['time', 'data.Depth', 'data.SoundSpeed'],
-                       '89': ['time', 'Reflectivity'],
+                       '89': ['time', 'Reflectivity', 'MinTravelTime', 'NormalBackscatter', 'ObliqueBackscatter', 'TVGCrossover'],
                        '110': ['data.Time', 'source_data.Latitude', 'source_data.Longitude',
                                'source_data.Altitude']}
 
@@ -127,14 +131,17 @@ recs_categories_translator_110 = {'65': {'Time': [['attitude', 'time']], 'Roll':
                                          'Serial#': [['ping', 'serial_num']], 'TiltAngle': [['ping', 'tiltangle']], 'Delay': [['ping', 'delay']],
                                          'Frequency': [['ping', 'frequency']], 'BeamPointingAngle': [['ping', 'beampointingangle']],
                                          'TransmitSectorID': [['ping', 'txsector_beam']], 'DetectionInfo': [['ping', 'detectioninfo']],
-                                         'QualityFactor': [['ping', 'qualityfactor']], 'TravelTime': [['ping', 'traveltime']]},
+                                         'QualityFactor': [['ping', 'qualityfactor']], 'TravelTime': [['ping', 'traveltime']],
+                                         'SignalLength': [['ping', 'pulselength']]},
                                   '82': {'time': [['runtime_params', 'time']], 'Mode': [['runtime_params', 'mode']],
                                          'ReceiverFixedGain': [['runtime_params', 'modetwo']],
                                          'YawAndPitchStabilization': [['runtime_params', 'yawpitchstab']],
                                          'settings': [['runtime_params', 'runtime_settings']]},
                                   '85': {'time': [['profile', 'time']], 'Depth': [['profile', 'depth']],
                                          'SoundSpeed': [['profile', 'soundspeed']]},
-                                  '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']]},
+                                  '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']],
+                                         'MinTravelTime': [['ping', 'mintraveltime']], 'NormalBackscatter': [['ping', 'normalbackscatter']],
+                                         'ObliqueBackscatter': [['ping', 'obliquebackscatter']], 'TVGCrossover': [['ping', 'tvgcrossover']]},
                                   '110': {'Time': [['navigation', 'time']], 'Latitude': [['navigation', 'latitude']],
                                           'Longitude': [['navigation', 'longitude']],
                                           'Altitude': [['navigation', 'altitude']]}}
@@ -144,10 +151,10 @@ oldstyle_recs_categories = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data
                             '102': ['time', 'PingCounter', 'SoundSpeed', 'SystemSerialNum',
                                     'rx.TiltAngle', 'rx.Delay', 'rx.CenterFrequency',
                                     'rx.BeamPointingAngle', 'rx.TransmitSectorID', 'rx.DetectionWindowLength',
-                                    'rx.QualityFactor', 'rx.TravelTime'],
+                                    'rx.QualityFactor', 'rx.TravelTime', 'rx.SignalLength'],
                             '82': ['time', 'header.Mode', 'header.ReceiverFixedGain', 'header.YawAndPitchStabilization', 'settings'],
                             '85': ['time', 'data.Depth', 'data.SoundSpeed'],
-                            '89': ['time', 'Reflectivity'],
+                            '89': ['time', 'Reflectivity', 'MinTravelTime', 'NormalBackscatter', 'ObliqueBackscatter', 'TVGCrossover'],
                             '80': ['time', 'Latitude', 'Longitude', 'gg_data.Altitude']}
 
 oldstyle_recs_categories_translator = {'65': {'Time': [['attitude', 'time']], 'Roll': [['attitude', 'roll']],
@@ -163,14 +170,17 @@ oldstyle_recs_categories_translator = {'65': {'Time': [['attitude', 'time']], 'R
                                                'TiltAngle': [['ping', 'tiltangle']], 'Delay': [['ping', 'delay']],
                                                'CenterFrequency': [['ping', 'frequency']], 'BeamPointingAngle': [['ping', 'beampointingangle']],
                                                'TransmitSectorID': [['ping', 'txsector_beam']], 'DetectionWindowLength': [['ping', 'detectioninfo']],
-                                               'QualityFactor': [['ping', 'qualityfactor']], 'TravelTime': [['ping', 'traveltime']]},
+                                               'QualityFactor': [['ping', 'qualityfactor']], 'TravelTime': [['ping', 'traveltime']],
+                                               'SignalLength': [['ping', 'pulselength']]},
                                        '82': {'time': [['runtime_params', 'time']], 'Mode': [['runtime_params', 'mode']],
                                               'ReceiverFixedGain': [['runtime_params', 'modetwo']],
                                               'YawAndPitchStabilization': [['runtime_params', 'yawpitchstab']],
                                               'settings': [['runtime_params', 'runtime_settings']]},
                                        '85': {'time': [['profile', 'time']], 'Depth': [['profile', 'depth']],
                                               'SoundSpeed': [['profile', 'soundspeed']]},
-                                       '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']]},
+                                       '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']],
+                                              'MinTravelTime': [['ping', 'mintraveltime']], 'NormalBackscatter': [['ping', 'normalbackscatter']],
+                                              'ObliqueBackscatter': [['ping', 'obliquebackscatter']], 'TVGCrossover': [['ping', 'tvgcrossover']]},
                                        '80': {'time': [['navigation', 'time']], 'Latitude': [['navigation', 'latitude']],
                                               'Longitude': [['navigation', 'longitude']],
                                               'Altitude': [['navigation', 'altitude']]}}
@@ -180,8 +190,9 @@ recs_categories_result = {'attitude':  {'time': None, 'roll': None, 'pitch': Non
                                                   'installation_settings': None},
                           'ping': {'time': None, 'rtime': None, 'counter': None, 'soundspeed': None, 'serial_num': None,
                                    'tiltangle': None, 'delay': None, 'frequency': None, 'reflectivity': None,
-                                   'beampointingangle': None, 'txsector_beam': None, 'detectioninfo': None,
-                                   'qualityfactor': None, 'traveltime': None},
+                                   'mintraveltime': None, 'normalbackscatter': None, 'obliquebackscatter': None,
+                                   'tvgcrossover': None, 'beampointingangle': None, 'txsector_beam': None,
+                                   'detectioninfo': None, 'qualityfactor': None, 'traveltime': None, 'pulselength': None},
                           'runtime_params': {'time': None, 'mode': None, 'modetwo': None, 'yawpitchstab': None,
                                              'runtime_settings': None},
                           'profile': {'time': None, 'depth': None, 'soundspeed': None},
@@ -411,8 +422,8 @@ class AllRead:
                 print(err)
             self.packet_read = False
     
-    def _better_merge_arrays(self, base_arr, arrone, arrtwo, arrthree):
-        newdtype = np.dtype(base_arr.dtype.descr + arrone.dtype.descr + arrtwo.dtype.descr + arrthree.dtype.descr)
+    def _better_merge_arrays(self, base_arr, arrone, arrtwo, arrthree, arrfour):
+        newdtype = np.dtype(base_arr.dtype.descr + arrone.dtype.descr + arrtwo.dtype.descr + arrthree.dtype.descr + arrfour.dtype.descr)
         newarray = np.empty(shape=base_arr.shape, dtype=newdtype)
         for field in base_arr.dtype.names:
             newarray[field] = base_arr[field]
@@ -422,6 +433,8 @@ class AllRead:
             newarray[field] = arrtwo[field]
         for field in arrthree.dtype.names:
             newarray[field] = arrthree[field]
+        for field in arrfour.dtype.names:
+            newarray[field] = arrfour[field]
         return newarray
     
     def _populate_rec(self):
@@ -462,32 +475,37 @@ class AllRead:
                 delay_array = rec.tx['Delay']
                 freq_array = rec.tx['Frequency']
                 tiltangle_array = rec.tx['TiltAngle']
+                pulselength_array = rec.tx['SignalLength']
                 freqname = 'Frequency'
             except:  # the data102 approach
                 if isinstance(rec.tx['Delay'], np.ndarray):
                     delay_array = rec.tx['Delay']
                     freq_array = rec.tx['CenterFrequency']
                     tiltangle_array = rec.tx['TiltAngle']
+                    pulselength_array = rec.tx['SignalLength']
                     freqname = 'CenterFrequency'
                 else:
                     delay_array = [rec.tx['Delay']]
                     freq_array = [rec.tx['CenterFrequency']]
                     tiltangle_array = [rec.tx['TiltAngle']]
+                    pulselength_array = [rec.tx['SignalLength']]
                     freqname = 'CenterFrequency'
 
             # expand out the sector wise arrays to be beam wise
             populated_delay = np.empty(rec.rx['TransmitSectorID'].shape, dtype=[('Delay', np.float32)])
             populated_freq = np.empty(rec.rx['TransmitSectorID'].shape, dtype=[(freqname, np.int32)])
             populated_tiltangle = np.empty(rec.rx['TransmitSectorID'].shape, dtype=[('TiltAngle', np.float32)])
+            populated_pulselength = np.empty(rec.rx['TransmitSectorID'].shape, dtype=[('SignalLength', np.float32)])
             for id in np.unique(rec.rx['TransmitSectorID']):
                 populated_delay[rec.rx['TransmitSectorID'] == id] = delay_array[id]
                 populated_freq[rec.rx['TransmitSectorID'] == id] = freq_array[id]
                 populated_tiltangle[rec.rx['TransmitSectorID'] == id] = tiltangle_array[id]
+                populated_pulselength[rec.rx['TransmitSectorID'] == id] = pulselength_array[id]
             
             #rec.rx = merge_arrays([rec.rx, populated_delay, populated_freq, populated_tiltangle], flatten=True)
-            rec.rx = self._better_merge_arrays(rec.rx, populated_delay, populated_freq, populated_tiltangle)
+            rec.rx = self._better_merge_arrays(rec.rx, populated_delay, populated_freq, populated_tiltangle, populated_pulselength)
 
-            new_tx_names = [n for n in rec.tx.dtype.names if n not in ['Delay', freqname, 'TiltAngle']]
+            new_tx_names = [n for n in rec.tx.dtype.names if n not in ['Delay', freqname, 'TiltAngle', 'SignalLength']]
             rec.tx = rec.tx[new_tx_names]
 
             return rec
@@ -735,7 +753,7 @@ class AllRead:
                         except:  # data80 approach, cast as numpy array, just one list of values
                             recs_to_read[rec][dgram] = np.array(recs_to_read[rec][dgram])
                 elif rec == 'ping':
-                    if dgram in ['reflectivity', 'rtime'] and not recs_to_read[rec][dgram]:
+                    if dgram in ['reflectivity', 'rtime', 'mintraveltime', 'normalbackscatter', 'obliquebackscatter', 'tvgcrossover'] and not recs_to_read[rec][dgram]:
                         pass
                     elif dgram == 'detectioninfo':
                         # same for detection info, but it also needs to be converted to something other than int8
@@ -779,11 +797,21 @@ class AllRead:
         recs_to_read['navigation']['latitude'] = recs_to_read['navigation']['latitude'].astype(float)
 
         # reflectivity comes from a different record, if it exists, we deal with it here
+        mt = recs_to_read['ping'].pop('mintraveltime')
+        bn = recs_to_read['ping'].pop('normalbackscatter')
+        bo = recs_to_read['ping'].pop('obliquebackscatter')
+        crossang = recs_to_read['ping'].pop('tvgcrossover')
         if recs_to_read['ping']['rtime'] is not None:
             if recs_to_read['ping']['time'].size != recs_to_read['ping']['rtime'].size:  # get indices of nearest intensity for each ping
                 rindex = np.searchsorted(recs_to_read['ping']['rtime'], recs_to_read['ping']['time']).clip(0, recs_to_read['ping']['rtime'].size - 1)
                 recs_to_read['ping']['reflectivity'] = recs_to_read['ping']['reflectivity'][rindex]
+                mt = mt[rindex]
+                bn = bn[rindex]
+                bo = bo[rindex]
+                crossang = crossang[rindex]
             recs_to_read['ping']['reflectivity'] = recs_to_read['ping']['reflectivity'].astype(np.float32)
+            recs_to_read['ping']['nearnormalcorrect'] = nearnormal_correction(mt, bn, bo, crossang, recs_to_read['ping']['soundspeed'],
+                                                                              recs_to_read['ping']['traveltime'])
         else:
             recs_to_read['ping'].pop('reflectivity')
         recs_to_read['ping'].pop('rtime')
@@ -3481,6 +3509,10 @@ class Data89(BaseData):
     def Reflectivity(self):  # added to support kluster read
         return [self.center().tolist()]
 
+    @property
+    def MinTravelTime(self):
+        return (self.RangeToNormal / 2) * (1 / self.SamplingFreq)
+
     def get_datablock(self, data=None):
         # FIXME: Not sure what happens if reshape is called
         part1 = super(Data89, self).get_datablock()
@@ -5878,6 +5910,55 @@ class useall(AllRead):
             self.tblfile.close()
         else:
             print("pytables module unavailable.")
+
+
+def nearnormal_correction(mintraveltime: np.ndarray, normalbackscatter: np.ndarray, obliquebackscatter: np.ndarray,
+                          crossoverangle: np.ndarray, surfsoundspeed: np.ndarray, twowaytraveltime: np.ndarray):
+    """
+    Generate the near normal backscatter corrector to backout the applied tvg used in .all backscatter.  We follow the
+    Kongsberg Jan2000 Hammerstad paper and guidance from UNH folks.  They provide the following:
+
+    NearNormal_Correction
+    (BSn – BSo) (1-sqrt( (R – R0) / (Rc – R0)))
+    BSn: BSnormal_dB
+    BSo: BSoblique_dB
+    R = twoWayTravelTime_sec * soundSpeedAtTxDepth_mPerSec  / 2
+    R0: minimum range in a swath
+    Rc = R0 / cos ( crossover_angle)
+    crossover_angle: You have to hunt for it in runtime_txt  - 'Normal Incidence Corr.'
+
+    Note that this is provided wrt KMALL processing reflectivity_1, but I believe this applies to the .all backscatter,
+    as reflectivity_1 is I believe supposed to follow the .all backscatter approach.
+
+    Parameters
+    ----------
+    mintraveltime
+        see seabed image data89 property, min travel time for ping, 1d array
+    normalbackscatter
+        see seabed image data89, 1d array
+    obliquebackscatter
+        see seabed image data89, 1d array
+    crossoverangle
+        see seabed image data89, 1d array
+    surfsoundspeed
+        surface soundspeed from data78, 1d array
+    twowaytraveltime
+        two way traveltime from data78, 2d array
+
+    Returns
+    -------
+    np.ndarray
+        2d array of near normal backscatter correction in db
+    """
+
+    minrng = mintraveltime * surfsoundspeed
+    rng = twowaytraveltime * surfsoundspeed[:, None] / 2
+    rngcross = minrng / np.cos(np.deg2rad(crossoverangle))
+
+    # range dependent parameter, clip to zero to avoid sqrt neg number issues
+    nncorrect_rngdep = ((rng - minrng[:, None]) / (rngcross[:, None] - minrng[:, None])).clip(0)
+    nncorrect = (normalbackscatter - obliquebackscatter)[:, None] * (1 - np.sqrt(nncorrect_rngdep))
+    return nncorrect.astype(np.float32)
 
 
 def print_some_records(file_object: AllRead, recordnum: int = 50):

--- a/HSTB/drivers/par3.py
+++ b/HSTB/drivers/par3.py
@@ -79,7 +79,7 @@ recs_categories_80 = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data.Heave
                       '82': ['time', 'header.Mode', 'header.ReceiverFixedGain', 'header.YawAndPitchStabilization', 'settings'],
                       '85': ['time', 'data.Depth', 'data.SoundSpeed'],
                       '80': ['time', 'Latitude', 'Longitude', 'gg_data.Altitude'],
-                      '89': ['time', 'Reflectivity', 'MinTravelTime', 'NormalBackscatter', 'ObliqueBackscatter', 'TVGCrossover']}
+                      '89': ['time', 'Reflectivity']}
 
 recs_categories_translator_80 = {'65': {'Time': [['attitude', 'time']], 'Roll': [['attitude', 'roll']],
                                         'Pitch': [['attitude', 'pitch']], 'Heave': [['attitude', 'heave']],
@@ -104,9 +104,7 @@ recs_categories_translator_80 = {'65': {'Time': [['attitude', 'time']], 'Roll': 
                                  '80': {'time': [['navigation', 'time']], 'Latitude': [['navigation', 'latitude']],
                                         'Longitude': [['navigation', 'longitude']],
                                         'Altitude': [['navigation', 'altitude']]},
-                                 '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']],
-                                        'MinTravelTime': [['ping', 'mintraveltime']], 'NormalBackscatter': [['ping', 'normalbackscatter']],
-                                        'ObliqueBackscatter': [['ping', 'obliquebackscatter']], 'TVGCrossover': [['ping', 'tvgcrossover']]}}
+                                 '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']]}}
 
 recs_categories_110 = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data.Heave', 'data.Heading'],
                        '73': ['time', 'header.Serial#', 'header.Serial#2', 'settings'],
@@ -115,7 +113,7 @@ recs_categories_110 = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data.Heav
                               'rx.TransmitSectorID', 'rx.DetectionInfo', 'rx.QualityFactor', 'rx.TravelTime', 'rx.SignalLength'],
                        '82': ['time', 'header.Mode', 'header.ReceiverFixedGain', 'header.YawAndPitchStabilization', 'settings'],
                        '85': ['time', 'data.Depth', 'data.SoundSpeed'],
-                       '89': ['time', 'Reflectivity', 'MinTravelTime', 'NormalBackscatter', 'ObliqueBackscatter', 'TVGCrossover'],
+                       '89': ['time', 'Reflectivity'],
                        '110': ['data.Time', 'source_data.Latitude', 'source_data.Longitude',
                                'source_data.Altitude']}
 
@@ -139,9 +137,7 @@ recs_categories_translator_110 = {'65': {'Time': [['attitude', 'time']], 'Roll':
                                          'settings': [['runtime_params', 'runtime_settings']]},
                                   '85': {'time': [['profile', 'time']], 'Depth': [['profile', 'depth']],
                                          'SoundSpeed': [['profile', 'soundspeed']]},
-                                  '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']],
-                                         'MinTravelTime': [['ping', 'mintraveltime']], 'NormalBackscatter': [['ping', 'normalbackscatter']],
-                                         'ObliqueBackscatter': [['ping', 'obliquebackscatter']], 'TVGCrossover': [['ping', 'tvgcrossover']]},
+                                  '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']]},
                                   '110': {'Time': [['navigation', 'time']], 'Latitude': [['navigation', 'latitude']],
                                           'Longitude': [['navigation', 'longitude']],
                                           'Altitude': [['navigation', 'altitude']]}}
@@ -154,7 +150,7 @@ oldstyle_recs_categories = {'65': ['data.Time', 'data.Roll', 'data.Pitch', 'data
                                     'rx.QualityFactor', 'rx.TravelTime', 'rx.SignalLength'],
                             '82': ['time', 'header.Mode', 'header.ReceiverFixedGain', 'header.YawAndPitchStabilization', 'settings'],
                             '85': ['time', 'data.Depth', 'data.SoundSpeed'],
-                            '89': ['time', 'Reflectivity', 'MinTravelTime', 'NormalBackscatter', 'ObliqueBackscatter', 'TVGCrossover'],
+                            '89': ['time', 'Reflectivity'],
                             '80': ['time', 'Latitude', 'Longitude', 'gg_data.Altitude']}
 
 oldstyle_recs_categories_translator = {'65': {'Time': [['attitude', 'time']], 'Roll': [['attitude', 'roll']],
@@ -178,9 +174,7 @@ oldstyle_recs_categories_translator = {'65': {'Time': [['attitude', 'time']], 'R
                                               'settings': [['runtime_params', 'runtime_settings']]},
                                        '85': {'time': [['profile', 'time']], 'Depth': [['profile', 'depth']],
                                               'SoundSpeed': [['profile', 'soundspeed']]},
-                                       '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']],
-                                              'MinTravelTime': [['ping', 'mintraveltime']], 'NormalBackscatter': [['ping', 'normalbackscatter']],
-                                              'ObliqueBackscatter': [['ping', 'obliquebackscatter']], 'TVGCrossover': [['ping', 'tvgcrossover']]},
+                                       '89': {'time': [['ping', 'rtime']], 'Reflectivity': [['ping', 'reflectivity']]},
                                        '80': {'time': [['navigation', 'time']], 'Latitude': [['navigation', 'latitude']],
                                               'Longitude': [['navigation', 'longitude']],
                                               'Altitude': [['navigation', 'altitude']]}}
@@ -190,8 +184,7 @@ recs_categories_result = {'attitude':  {'time': None, 'roll': None, 'pitch': Non
                                                   'installation_settings': None},
                           'ping': {'time': None, 'rtime': None, 'counter': None, 'soundspeed': None, 'serial_num': None,
                                    'tiltangle': None, 'delay': None, 'frequency': None, 'reflectivity': None,
-                                   'mintraveltime': None, 'normalbackscatter': None, 'obliquebackscatter': None,
-                                   'tvgcrossover': None, 'beampointingangle': None, 'txsector_beam': None,
+                                   'beampointingangle': None, 'txsector_beam': None,
                                    'detectioninfo': None, 'qualityfactor': None, 'traveltime': None, 'pulselength': None},
                           'runtime_params': {'time': None, 'mode': None, 'modetwo': None, 'yawpitchstab': None,
                                              'runtime_settings': None},
@@ -797,21 +790,11 @@ class AllRead:
         recs_to_read['navigation']['latitude'] = recs_to_read['navigation']['latitude'].astype(float)
 
         # reflectivity comes from a different record, if it exists, we deal with it here
-        mt = recs_to_read['ping'].pop('mintraveltime')
-        bn = recs_to_read['ping'].pop('normalbackscatter')
-        bo = recs_to_read['ping'].pop('obliquebackscatter')
-        crossang = recs_to_read['ping'].pop('tvgcrossover')
         if recs_to_read['ping']['rtime'] is not None:
             if recs_to_read['ping']['time'].size != recs_to_read['ping']['rtime'].size:  # get indices of nearest intensity for each ping
                 rindex = np.searchsorted(recs_to_read['ping']['rtime'], recs_to_read['ping']['time']).clip(0, recs_to_read['ping']['rtime'].size - 1)
                 recs_to_read['ping']['reflectivity'] = recs_to_read['ping']['reflectivity'][rindex]
-                mt = mt[rindex]
-                bn = bn[rindex]
-                bo = bo[rindex]
-                crossang = crossang[rindex]
             recs_to_read['ping']['reflectivity'] = recs_to_read['ping']['reflectivity'].astype(np.float32)
-            recs_to_read['ping']['nearnormalcorrect'] = nearnormal_correction(mt, bn, bo, crossang, recs_to_read['ping']['soundspeed'],
-                                                                              recs_to_read['ping']['traveltime'])
         else:
             recs_to_read['ping'].pop('reflectivity')
         recs_to_read['ping'].pop('rtime')
@@ -5919,7 +5902,7 @@ def nearnormal_correction(mintraveltime: np.ndarray, normalbackscatter: np.ndarr
     Kongsberg Jan2000 Hammerstad paper and guidance from UNH folks.  They provide the following:
 
     NearNormal_Correction
-    (BSn – BSo) (1-sqrt( (R – R0) / (Rc – R0)))
+    (BSo – BSn) (1-sqrt( (R – R0) / (Rc – R0)))
     BSn: BSnormal_dB
     BSo: BSoblique_dB
     R = twoWayTravelTime_sec * soundSpeedAtTxDepth_mPerSec  / 2
@@ -5929,6 +5912,8 @@ def nearnormal_correction(mintraveltime: np.ndarray, normalbackscatter: np.ndarr
 
     Note that this is provided wrt KMALL processing reflectivity_1, but I believe this applies to the .all backscatter,
     as reflectivity_1 is I believe supposed to follow the .all backscatter approach.
+
+    Not currently included in Kluster as I can't seem to get anything from it that makes sense.
 
     Parameters
     ----------
@@ -5957,7 +5942,7 @@ def nearnormal_correction(mintraveltime: np.ndarray, normalbackscatter: np.ndarr
 
     # range dependent parameter, clip to zero to avoid sqrt neg number issues
     nncorrect_rngdep = ((rng - minrng[:, None]) / (rngcross[:, None] - minrng[:, None])).clip(0)
-    nncorrect = (normalbackscatter - obliquebackscatter)[:, None] * (1 - np.sqrt(nncorrect_rngdep))
+    nncorrect = (obliquebackscatter - normalbackscatter)[:, None] * (1 - np.sqrt(nncorrect_rngdep))
     return nncorrect.astype(np.float32)
 
 

--- a/HSTB/drivers/prr3.py
+++ b/HSTB/drivers/prr3.py
@@ -858,7 +858,8 @@ class X7kRead:
         if recs_to_read['ping']['reflectivity'] is None or (recs_to_read['ping']['reflectivity'] == 0).all():
             recs_to_read['ping'].pop('reflectivity')
         else:
-            recs_to_read['ping']['reflectivity'] = recs_to_read['ping']['reflectivity'].astype(np.float32)
+            # have to convert to decibels, from raw amplitudes (from conversations with Mike Smith/UNH)
+            recs_to_read['ping']['reflectivity'] = (20 * np.log10(recs_to_read['ping']['reflectivity'])).astype(np.float32)
 
         recs_to_read['runtime_params']['time'] = np.array([recs_to_read['runtime_params']['time'][0]], dtype=float)
         recs_to_read['runtime_params']['runtime_settings'] = np.array(recs_to_read['runtime_params']['runtime_settings'], dtype=np.object)

--- a/HSTB/drivers/prr3.py
+++ b/HSTB/drivers/prr3.py
@@ -968,10 +968,27 @@ class X7kRead:
             self.at_right_byte = False  # for now assume that if a custom start pointer is provided, we need to seek the start byte
         self.infile.seek(self.start_ptr)
         self.eof = False
+        last_nav_blob = False
+        reading_last_navblob = False
+        found_last_navblob = False
+        oldfilelen = self.filelen
+        desired_datagrams = list(categories.keys())
+        if self.end_ptr and (self.end_ptr != self.max_filelen) and '1003' in desired_datagrams:
+            # When you use end pointer to read only a segment of a file, you need to continue reading to get the last
+            #  navigation blob after the end pointer.  This is due to how Reson sonars log 1003 in big blobs throughout
+            #  the file, and not sequentially along with the ping records.
+            last_nav_blob = True
         while not self.eof:
             self.read()  # find the start of the record and read the header
+            if self.eof and last_nav_blob:  # you've hit the end pointer, but we want to continue to get the last navigation blob
+                reading_last_navblob = True
+                desired_datagrams = ['1003']
+                self.filelen = self.max_filelen - self.start_ptr
+                self.eof = False
             datagram_type = str(self.packet.dtype)
-            if datagram_type in list(categories.keys()):  # if the header indicates this is a record you want...
+            if datagram_type in desired_datagrams:  # if the header indicates this is a record you want...
+                if reading_last_navblob:
+                    found_last_navblob = True
                 for rec_ident in list(category_translator[datagram_type].values())[0]:
                     recs_count[rec_ident[0]] += 1
                 self.get()  # read the rest of the datagram and decode the data
@@ -1018,6 +1035,10 @@ class X7kRead:
                                 recs_to_read[translated[0]][translated[1]] = copy.copy(val)
                             else:
                                 recs_to_read[translated[0]][translated[1]].extend(val)
+            elif found_last_navblob:
+                last_nav_blob = False
+                self.filelen = oldfilelen
+                self.eof = True
 
             if first_installation_rec:
                 if datagram_type == '7030':
@@ -2257,24 +2278,24 @@ class Data7028(BaseData):
 
     def read(self, datablock):
         if self.header['ErrorFlags'] == 0:
-            self.descriptor = np.zeros((self.numpoints, 4))
+            self.descriptor = np.zeros((self.numdetections, 4))
             strt_counter = 0
             fmt_descriptor = '<H3I'
             descriptor_sz = struct.calcsize(fmt_descriptor)
-            for beam in range(self.numpoints):
+            for beam in range(self.numdetections):
                 self.descriptor[beam, :] = struct.unpack(fmt_descriptor, datablock[strt_counter:strt_counter + descriptor_sz])
                 strt_counter += descriptor_sz
             self.beamwindow = self.descriptor[:, 3] - self.descriptor[:, 1] + 1
             self.maxbeam = int(self.descriptor[:, 0].max()) + 1
-            self.maxwindow = self.beamwindow.max()
+            self.maxwindow = int(self.beamwindow.max())
             self.snippets = np.zeros((self.maxbeam, self.maxwindow))
-            for beam in range(self.numpoints):
+            for beam in range(self.numdetections):
                 fmt_data = '<' + str(int(self.beamwindow[beam])) + 'H'
                 data_sz = struct.calcsize(fmt_data)
                 startoffset = int((self.maxwindow - self.beamwindow[beam]) / 2)
                 beam_data = struct.unpack(fmt_data, datablock[strt_counter:strt_counter + data_sz])
                 strt_counter += data_sz
-                self.snippets[int(self.descriptor[beam, 0]), startoffset: startoffset + self.beamwindow[beam]] = beam_data
+                self.snippets[int(self.descriptor[beam, 0]), startoffset: startoffset + int(self.beamwindow[beam])] = beam_data
 
 
 class Data7030(BaseData):


### PR DESCRIPTION
drivers 0.3.0
    - include backscatter specific variables for all multibeam drivers in sequential read records
    - fix for kmall sonar with varying beam counts across pings in sequential read records