### PR TITLE
Assign sonar serial number(s) with missing 7001 record

### DIFF
--- a/HSTB/drivers/prr3.py
+++ b/HSTB/drivers/prr3.py
@@ -874,6 +874,10 @@ class X7kRead:
         # cover the instance where there is no 7030 record for install params
         if not recs_to_read['installation_params']['time'].any() and not has_installation_rec:
             recs_to_read['installation_params'] = self.return_empty_installparams(sonarmodelnumber, serialnumber, serialnumbertwo, runtime=runtime)['installation_params']
+        # cover the instance where there is no 7001 record for serial numbers
+        if not recs_to_read['installation_params']['serial_one'].any():
+            recs_to_read['installation_params']['serial_one'] = np.array([serialnumber], dtype=np.dtype('uint64'))
+            recs_to_read['installation_params']['serial_two'] = np.array([serialnumbertwo], dtype=np.dtype('uint64'))
 
         # # I do this in the other drivers, might include it later...
         #


### PR DESCRIPTION
I've been having some issues correctly reading s7k files in the Kluster software. I traced the problem to the python Reson reader (prr3.py). Basically, my s7k files don't have a 7001 record. They were generated from a Teledyn-RESON Seabat 7125-SV2 using the Teledyne-PDS software.

The python Reson reader actually spots that there is no 7001 record and assign the value 0 as serial number instead. But that default value never gets assigned to the installation parameters. So I added a piece of code to solve the problem, but I'm really unsure about the change. It might break backward compatibility. Could you confirm if my change makes sense? Would you have a better suggestion?